### PR TITLE
add AiForTheChurch

### DIFF
--- a/backend/danswer/configs/constants.py
+++ b/backend/danswer/configs/constants.py
@@ -102,6 +102,7 @@ class ModelHostType(str, Enum):
     HUGGINGFACE = "huggingface"  # HuggingFace test-generation Inference API
     # https://medium.com/@yuhongsun96/host-a-llama-2-api-on-gpu-for-free-a5311463c183
     COLAB_DEMO = "colab-demo"
+    AI_FOR_THE_CHURCH = "AiForTheChurch"
     # TODO support for Azure, AWS, GCP GenAI model hosting
 
 

--- a/backend/danswer/configs/constants.py
+++ b/backend/danswer/configs/constants.py
@@ -102,7 +102,7 @@ class ModelHostType(str, Enum):
     HUGGINGFACE = "huggingface"  # HuggingFace test-generation Inference API
     # https://medium.com/@yuhongsun96/host-a-llama-2-api-on-gpu-for-free-a5311463c183
     COLAB_DEMO = "colab-demo"
-    AI_FOR_THE_CHURCH = "AiForTheChurch"
+    AI_FOR_THE_CHURCH = "ai-for-the-church"
     # TODO support for Azure, AWS, GCP GenAI model hosting
 
 

--- a/backend/danswer/direct_qa/llm_utils.py
+++ b/backend/danswer/direct_qa/llm_utils.py
@@ -123,6 +123,7 @@ def get_default_qa_model(
         if (
             model_host_type == ModelHostType.HUGGINGFACE.value
             or model_host_type == ModelHostType.COLAB_DEMO.value
+            or model_host_type == ModelHostType.AI_FOR_THE_CHURCH.value
         ):
             # Assuming user is hosting the smallest size LLMs with weaker capabilities and token limits
             # With the 7B Llama2 Chat model, there is a max limit of 1512 tokens


### PR DESCRIPTION
Hasn't been tested because I haven't set up Danswer myself so proceed with caution.

I believe these are the environment variables that need to be set:
```
export GEN_AI_ENDPOINT=https://api.aiforthechurch.org/inference/v1/chat/completions/
export GEN_AI_HOST_TYPE=ai-for-the-church
```

If we receive an error `Unknown LLM model: ai-for-the-church` I will need to implement one more class to make this work.